### PR TITLE
UIGS-8 Define `From field` and `Path` and allow `Custom Path` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,6 @@
 * Module setup. Refs UIGS-1.
 * Add GOBI integration area to FOLIO settings. Refs UIGS-2.
 * Display GOBI integration Configuration files and mappings. Refs UIGS-4.
+* Allow user to edit mappings. Refs UIGS-5.
 * Allow user to reset to default configuration. Refs UIGS-6.
+* Define From field name and Path and allow Custom path option. Refs UIGS-8.

--- a/src/settings/MappingConfiguration/MappingForm/MappingForm.js
+++ b/src/settings/MappingConfiguration/MappingForm/MappingForm.js
@@ -28,7 +28,10 @@ import {
   ORDER_MAPPING_ACCORDIONS_TITLES,
   ORDER_MAPPING_FIELDS_ACCORDIONS_MAP,
 } from '../../constants';
-import { getTranslatorOptions } from '../utils';
+import {
+  getFieldNameOptions,
+  getTranslatorOptions,
+} from '../utils';
 import { MappingFormFooter } from './MappingFormFooter';
 
 const MappingForm = ({
@@ -49,6 +52,7 @@ const MappingForm = ({
     toggleSection,
   ] = useAccordionToggle(INITIAL_ORDER_MAPPING_ACCORDIONS);
 
+  const fieldNameOptions = useMemo(() => getFieldNameOptions(), []);
   const translatorOptions = useMemo(() => getTranslatorOptions(intl, translators), [intl, translators]);
 
   const shortcuts = [
@@ -103,6 +107,7 @@ const MappingForm = ({
                 name={fieldName}
                 field={values[fieldName]}
                 change={change}
+                fieldNameOptions={fieldNameOptions}
                 translatorOptions={translatorOptions}
               />
             ))}
@@ -110,7 +115,12 @@ const MappingForm = ({
         </Row>
       </Accordion>
     ))
-  ), [change, translatorOptions, values]);
+  ), [
+    change,
+    fieldNameOptions,
+    translatorOptions,
+    values,
+  ]);
 
   return (
     <HasCommand

--- a/src/settings/MappingConfiguration/MappingsList/MappingsList.js
+++ b/src/settings/MappingConfiguration/MappingsList/MappingsList.js
@@ -1,8 +1,15 @@
 import PropTypes from 'prop-types';
+import { useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { camelCase } from 'lodash';
 
-import { NavList, NavListItem, Pane } from '@folio/stripes/components';
+import {
+  Layout,
+  Loading,
+  NavList,
+  NavListItem,
+  Pane,
+} from '@folio/stripes/components';
 import { usePaneFocus } from '@folio/stripes-acq-components';
 
 import { useOrderMappingTypes } from '../../hooks';
@@ -10,7 +17,22 @@ import { FORMATTED_ORDER_MAPPING_TYPES } from '../../constants';
 
 export const MappingsList = ({ history, match }) => {
   const { paneTitleRef } = usePaneFocus();
-  const { orderMappingTypes } = useOrderMappingTypes();
+  const {
+    isLoading,
+    orderMappingTypes,
+  } = useOrderMappingTypes();
+
+  const mappingsList = useMemo(() => (
+    orderMappingTypes.map((type) => (
+      <NavListItem
+        data-testid="mapping-type-list-item"
+        key={type}
+        onClick={() => history.push(`${match.path}/${camelCase(type)}/view`)}
+      >
+        {FORMATTED_ORDER_MAPPING_TYPES[camelCase(type)]}
+      </NavListItem>
+    ))
+  ), [history, match.path, orderMappingTypes]);
 
   return (
     <Pane
@@ -20,15 +42,15 @@ export const MappingsList = ({ history, match }) => {
       paneTitleRef={paneTitleRef}
     >
       <NavList>
-        {orderMappingTypes.map((type) => (
-          <NavListItem
-            data-testid="mapping-type-list-item"
-            key={type}
-            onClick={() => history.push(`${match.path}/${camelCase(type)}/view`)}
-          >
-            {FORMATTED_ORDER_MAPPING_TYPES[camelCase(type)]}
-          </NavListItem>
-        ))}
+        {
+          isLoading
+            ? (
+              <Layout className="display-flex centerContent">
+                <Loading size="large" />
+              </Layout>
+            )
+            : mappingsList
+        }
       </NavList>
     </Pane>
   );

--- a/src/settings/MappingConfiguration/utils/getFieldNameOptions.js
+++ b/src/settings/MappingConfiguration/utils/getFieldNameOptions.js
@@ -1,0 +1,16 @@
+import {
+  CUSTOM_PATH,
+  GOBI_FIELDS,
+} from '../../constants';
+
+export const getFieldNameOptions = () => {
+  const fieldOptions = Object.values(GOBI_FIELDS).map(value => ({
+    label: value,
+    value,
+  }));
+
+  return [
+    ...fieldOptions,
+    { label: CUSTOM_PATH, value: CUSTOM_PATH },
+  ];
+};

--- a/src/settings/MappingConfiguration/utils/index.js
+++ b/src/settings/MappingConfiguration/utils/index.js
@@ -1,2 +1,3 @@
+export * from './getFieldNameOptions';
 export * from './getTranslatorOptions';
 export * from './mappings';

--- a/src/settings/components/FieldFromFieldName/FieldFromFieldName.js
+++ b/src/settings/components/FieldFromFieldName/FieldFromFieldName.js
@@ -1,22 +1,40 @@
 import PropTypes from 'prop-types';
-
-import { Field } from 'react-final-form';
+import { useCallback } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { TextField } from '@folio/stripes/components';
+
+import {
+  FieldSelectionFinal,
+} from '@folio/stripes-acq-components';
+
+import { GOBI_FIELDS_PATH_MAP } from '../../constants';
 
 export const FieldFromFieldName = ({
+  change,
+  dataOptions,
+  mappingFieldName,
   name,
 }) => {
+  const onChange = useCallback((gobiFieldName) => {
+    const fieldPath = GOBI_FIELDS_PATH_MAP[gobiFieldName];
+
+    change(name, gobiFieldName || undefined);
+    change(`${mappingFieldName}.dataSource.from`, fieldPath);
+  }, [change, mappingFieldName, name]);
+
   return (
-    <Field
+    <FieldSelectionFinal
       name={name}
-      component={TextField}
+      dataOptions={dataOptions}
       id={`from-field-name-${name}`}
       label={<FormattedMessage id="ui-gobi-settings.order.mappings.field.dataSource.fromFieldName" />}
+      onChange={onChange}
     />
   );
 };
 
 FieldFromFieldName.propTypes = {
+  change: PropTypes.func.isRequired,
+  dataOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
+  mappingFieldName: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
 };

--- a/src/settings/components/FieldFromFieldName/FieldFromFieldName.test.js
+++ b/src/settings/components/FieldFromFieldName/FieldFromFieldName.test.js
@@ -1,10 +1,15 @@
-import { render, screen } from '@testing-library/react';
+import user from '@testing-library/user-event';
+import { act, render, screen } from '@testing-library/react';
 import { Form } from 'react-final-form';
 
+import { getFieldNameOptions } from '../../MappingConfiguration/utils';
 import { FieldFromFieldName } from './FieldFromFieldName';
 
 const defaultProps = {
-  name: 'name',
+  change: jest.fn(),
+  dataOptions: getFieldNameOptions(),
+  mappingFieldName: 'PREFIX',
+  name: 'PREFIX.dataSource.dataSourceFieldName',
 };
 
 const renderFieldFromFieldName = (props = {}) => render(
@@ -24,5 +29,18 @@ describe('FieldFromFieldName', () => {
     renderFieldFromFieldName();
 
     expect(screen.getByText('ui-gobi-settings.order.mappings.field.dataSource.fromFieldName')).toBeInTheDocument();
+  });
+
+  it('should change \'Path\' when gobi field name was changed', async () => {
+    renderFieldFromFieldName();
+
+    const selectionBtn = screen.getByText('ui-gobi-settings.order.mappings.field.dataSource.fromFieldName');
+
+    await act(async () => {
+      user.click(selectionBtn);
+      user.click(screen.getByText(defaultProps.dataOptions[1].label));
+    });
+
+    expect(defaultProps.change).toHaveBeenCalled();
   });
 });

--- a/src/settings/components/FieldFromPath/FieldFromPath.js
+++ b/src/settings/components/FieldFromPath/FieldFromPath.js
@@ -1,0 +1,35 @@
+import PropTypes from 'prop-types';
+import { Field } from 'react-final-form';
+import { FormattedMessage } from 'react-intl';
+
+import { KeyValue, TextField } from '@folio/stripes/components';
+
+import { CUSTOM_PATH } from '../../constants';
+
+export const FieldFromPath = ({
+  mappingField,
+  name,
+}) => {
+  const isCustomPath = mappingField.dataSource?.dataSourceFieldName === CUSTOM_PATH;
+
+  return isCustomPath
+    ? (
+      <Field
+        name={name}
+        component={TextField}
+        id={`from-field-path-${name}`}
+        label={<FormattedMessage id="ui-gobi-settings.order.mappings.field.dataSource.fromFieldPath" />}
+      />
+    )
+    : (
+      <KeyValue
+        label={<FormattedMessage id="ui-gobi-settings.order.mappings.field.dataSource.fromFieldPath" />}
+        value={mappingField.dataSource?.from}
+      />
+    );
+};
+
+FieldFromPath.propTypes = {
+  mappingField: PropTypes.object.isRequired,
+  name: PropTypes.string.isRequired,
+};

--- a/src/settings/components/FieldFromPath/FieldFromPath.test.js
+++ b/src/settings/components/FieldFromPath/FieldFromPath.test.js
@@ -1,0 +1,60 @@
+import user from '@testing-library/user-event';
+import { act, render, screen } from '@testing-library/react';
+import { Form } from 'react-final-form';
+
+import {
+  CUSTOM_PATH,
+  GOBI_FIELDS,
+  GOBI_FIELDS_PATH_MAP,
+} from '../../constants';
+import { FieldFromPath } from './FieldFromPath';
+
+const defaultProps = {
+  mappingField: {
+    field: 'SUFFIX',
+    dataSource: {
+      dataSourceFieldName: GOBI_FIELDS.localData4,
+      from: GOBI_FIELDS_PATH_MAP[GOBI_FIELDS.localData4],
+    },
+  },
+  name: 'SUFFIX',
+};
+
+const renderFieldFromPath = (props = {}) => render(
+  <Form
+    onSubmit={() => jest.fn()}
+    render={() => (
+      <FieldFromPath
+        {...defaultProps}
+        {...props}
+      />
+    )}
+  />,
+);
+
+describe('FieldFromPath', () => {
+  it('should render field \'Path\'', () => {
+    renderFieldFromPath();
+
+    expect(screen.getByText('ui-gobi-settings.order.mappings.field.dataSource.fromFieldPath')).toBeInTheDocument();
+  });
+
+  it('should render field \'Path\' as text input if it is custom', () => {
+    renderFieldFromPath({
+      mappingField: {
+        ...defaultProps.mappingField,
+        dataSource: {
+          ...defaultProps.mappingField.dataSource,
+          dataSourceFieldName: CUSTOM_PATH,
+        },
+      },
+    });
+
+    const pathInput = screen.getByLabelText('ui-gobi-settings.order.mappings.field.dataSource.fromFieldPath');
+    const customPath = '//Suffix';
+
+    user.type(pathInput, customPath);
+
+    expect(pathInput.value).toEqual(customPath);
+  });
+});

--- a/src/settings/components/FieldFromPath/FieldFromPath.test.js
+++ b/src/settings/components/FieldFromPath/FieldFromPath.test.js
@@ -1,5 +1,5 @@
 import user from '@testing-library/user-event';
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Form } from 'react-final-form';
 
 import {

--- a/src/settings/components/FieldFromPath/index.js
+++ b/src/settings/components/FieldFromPath/index.js
@@ -1,0 +1,1 @@
+export { FieldFromPath } from './FieldFromPath';

--- a/src/settings/components/FieldTranslateDefault/FieldTranslateDefault.js
+++ b/src/settings/components/FieldTranslateDefault/FieldTranslateDefault.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-
 import { Field } from 'react-final-form';
 
 import { Checkbox } from '@folio/stripes/components';

--- a/src/settings/components/FieldTranslator/FieldTranslator.js
+++ b/src/settings/components/FieldTranslator/FieldTranslator.js
@@ -1,35 +1,24 @@
 import PropTypes from 'prop-types';
-import { useCallback } from 'react';
 
 import {
   FieldSelectionFinal,
 } from '@folio/stripes-acq-components';
 
 export const FieldTranslator = ({
-  change,
   dataOptions = [],
-  mappingFieldName,
   name,
 }) => {
-  const onChange = useCallback((translator) => {
-    change(name, translator || undefined);
-    change(`${mappingFieldName}.dataSource.default`, undefined);
-  }, [change, mappingFieldName, name]);
-
   return (
     <FieldSelectionFinal
       dataOptions={dataOptions}
       id={`translator-${name}`}
       labelId="ui-gobi-settings.order.mappings.field.dataSource.translator"
       name={name}
-      onChange={onChange}
     />
   );
 };
 
 FieldTranslator.propTypes = {
-  change: PropTypes.func.isRequired,
   dataOptions: PropTypes.arrayOf(PropTypes.object),
-  mappingFieldName: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
 };

--- a/src/settings/components/FieldTranslator/FieldTranslator.test.js
+++ b/src/settings/components/FieldTranslator/FieldTranslator.test.js
@@ -1,16 +1,13 @@
-import user from '@testing-library/user-event';
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Form } from 'react-final-form';
 
 import { FieldTranslator } from './FieldTranslator';
 
 const defaultProps = {
-  change: jest.fn(),
   dataOptions: [
     { label: 'lookup 1', value: 'lookup1' },
     { label: 'lookup 2', value: 'lookup2' },
   ],
-  mappingFieldName: 'PREFIX',
   name: 'name',
 };
 
@@ -27,26 +24,9 @@ const renderFieldTranslator = (props = {}) => render(
 );
 
 describe('FieldTranslator', () => {
-  beforeEach(() => {
-    defaultProps.change.mockClear();
-  });
-
   it('should render field \'Translation\'', () => {
     renderFieldTranslator();
 
     expect(screen.getByText('ui-gobi-settings.order.mappings.field.dataSource.translator')).toBeInTheDocument();
-  });
-
-  it('should change \'Default value\' when translation was changed', async () => {
-    renderFieldTranslator();
-
-    const selectionBtn = screen.getByText('ui-gobi-settings.order.mappings.field.dataSource.translator');
-
-    await act(async () => {
-      user.click(selectionBtn);
-      user.click(screen.getByText(defaultProps.dataOptions[1].label));
-    });
-
-    expect(defaultProps.change).toHaveBeenCalled();
   });
 });

--- a/src/settings/components/MappingFieldEdit/MappingFieldEdit.js
+++ b/src/settings/components/MappingFieldEdit/MappingFieldEdit.js
@@ -51,9 +51,7 @@ const MappingFieldEditComponent = ({
         <Col xs={6} md={3}>
           <FieldTranslator
             name={`${name}.dataSource.translation`}
-            change={change}
             dataOptions={translatorOptions}
-            mappingFieldName={name}
           />
         </Col>
 

--- a/src/settings/components/MappingFieldEdit/MappingFieldEdit.js
+++ b/src/settings/components/MappingFieldEdit/MappingFieldEdit.js
@@ -1,15 +1,14 @@
 import PropTypes from 'prop-types';
 import { memo } from 'react';
-import { FormattedMessage } from 'react-intl';
 
 import {
   Col,
-  KeyValue,
   Row,
 } from '@folio/stripes/components';
 
 import { FieldDefaultValue } from '../FieldDefaultValue';
 import { FieldFromFieldName } from '../FieldFromFieldName';
+import { FieldFromPath } from '../FieldFromPath';
 import { FieldTranslator } from '../FieldTranslator';
 import { FieldTranslateDefault } from '../FieldTranslateDefault';
 import { MappingFieldCard } from '../MappingFieldCard';
@@ -17,6 +16,7 @@ import { MappingFieldCard } from '../MappingFieldCard';
 const MappingFieldEditComponent = ({
   change,
   field = {},
+  fieldNameOptions,
   name,
   translatorOptions,
 }) => {
@@ -29,13 +29,16 @@ const MappingFieldEditComponent = ({
         <Col xs={6} md={3}>
           <FieldFromFieldName
             name={`${name}.dataSource.dataSourceFieldName`}
+            change={change}
+            dataOptions={fieldNameOptions}
+            mappingFieldName={name}
           />
         </Col>
 
         <Col xs={6} md={3}>
-          <KeyValue
-            label={<FormattedMessage id="ui-gobi-settings.order.mappings.field.dataSource.fromFieldPath" />}
-            value={field.dataSource?.from}
+          <FieldFromPath
+            mappingField={field}
+            name={`${name}.dataSource.from`}
           />
         </Col>
 
@@ -67,6 +70,7 @@ const MappingFieldEditComponent = ({
 MappingFieldEditComponent.propTypes = {
   change: PropTypes.func.isRequired,
   field: PropTypes.object,
+  fieldNameOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
   name: PropTypes.string.isRequired,
   translatorOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
 };

--- a/src/settings/components/MappingFieldEdit/MappingFieldEdit.test.js
+++ b/src/settings/components/MappingFieldEdit/MappingFieldEdit.test.js
@@ -1,11 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import { Form } from 'react-final-form';
 
+import { getFieldNameOptions } from '../../MappingConfiguration/utils';
 import { MappingFieldEdit } from './MappingFieldEdit';
 
 const defaultProps = {
   change: jest.fn(),
   name: 'PREFIX',
+  fieldNameOptions: getFieldNameOptions(),
   translatorOptions: [
     { label: 'lookup 1', value: 'lookup1' },
     { label: 'lookup 2', value: 'lookup2' },

--- a/src/settings/components/index.js
+++ b/src/settings/components/index.js
@@ -1,5 +1,6 @@
 export { FieldDefaultValue } from './FieldDefaultValue';
 export { FieldFromFieldName } from './FieldFromFieldName';
+export { FieldFromPath } from './FieldFromPath';
 export { FieldTranslateDefault } from './FieldTranslateDefault';
 export { FieldTranslator } from './FieldTranslator';
 export { MappingFieldCard } from './MappingFieldCard';

--- a/src/settings/constants/mapping.js
+++ b/src/settings/constants/mapping.js
@@ -104,3 +104,49 @@ export const FIELDS = {
   VOLUMES: 'VOLUMES',
   WORKFLOW_STATUS: 'WORKFLOW_STATUS',
 };
+
+export const CUSTOM_PATH = 'Custom Path';
+
+export const GOBI_FIELDS = {
+  baseAccount: 'Base Account',
+  subAccount: 'Sub Account',
+  title: 'Title',
+  productId: 'Product ID',
+  productQualifier: 'Product Qualifier',
+  publicationDate: 'Publication Date',
+  publisher: 'Publisher',
+  contributor: 'Contributor',
+  fundCode: 'Fund Code',
+  location: 'Location',
+  quantity: 'Quantity',
+  ypbOrderKey: 'YBP Order Key',
+  orderPlaced: 'Order Placed',
+  unitPrice: 'Unit Price',
+  currency: 'Currency',
+  localData1: 'Local Data 1',
+  localData2: 'Local Data 2',
+  localData3: 'Local Data 3',
+  localData4: 'Local Data 4',
+};
+
+export const GOBI_FIELDS_PATH_MAP = {
+  [GOBI_FIELDS.baseAccount]: '//BaseAccount',
+  [GOBI_FIELDS.subAccount]: '//SubAccount',
+  [GOBI_FIELDS.title]: '//datafield[@tag=\'245\']/*',
+  [GOBI_FIELDS.productId]: '//datafield[@tag=\'020\']/subfield[@code=\'a\']',
+  [GOBI_FIELDS.productQualifier]: '//datafield[@tag=\'020\']/subfield[@code=\'q\']',
+  [GOBI_FIELDS.publicationDate]: '//datafield[@tag=\'260\']/subfield[@code=\'c\']',
+  [GOBI_FIELDS.publisher]: '//datafield[@tag=\'260\']/subfield[@code=\'b\']',
+  [GOBI_FIELDS.contributor]: '//datafield[@tag=\'100\']/*',
+  [GOBI_FIELDS.fundCode]: '//fundcode',
+  [GOBI_FIELDS.location]: '//Location',
+  [GOBI_FIELDS.quantity]: '//Quantity',
+  [GOBI_FIELDS.ypbOrderKey]: '//YBPOrderKey',
+  [GOBI_FIELDS.orderPlaced]: '//OrderPlaced',
+  [GOBI_FIELDS.unitPrice]: '//ListPrice/Amount',
+  [GOBI_FIELDS.currency]: '//ListPrice/Currency',
+  [GOBI_FIELDS.localData1]: '//LocalData[Description=\'LocalData1\']/Value',
+  [GOBI_FIELDS.localData2]: '//LocalData[Description=\'LocalData2\']/Value',
+  [GOBI_FIELDS.localData3]: '//LocalData[Description=\'LocalData3\']/Value',
+  [GOBI_FIELDS.localData4]: '//LocalData[Description=\'LocalData4\']/Value',
+};


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"
  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIGS-8
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Bind static list of GOBI fields with related XPaths;
- Use `<FieldSelectionFinal>` final form field instead of `<TextField>` for `<FieldFromFieldName>` component;
- Replace `<KeyValue>` with new `FieldFromPath` component in edit mappings form;
- Update `Path` value when `From field` value was changed;
- Replace `<KeyValue>` component with `<TextField>` when `From field` value equals to "Custom Path" to allow an user edit `Path` by hands;
- Add unit tests for new code and update existing tests;

### Additional scope:
- Add `Loading` component to indicate user that order mapping types are loading;
- Remove `Default value` resetting on `Translation` change, because  `Default value` is a text input for now.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.

![editGobiMapping](https://user-images.githubusercontent.com/88109087/186343197-f2eb92ad-f8bd-4d9c-be19-208851429fed.gif)

