### PR TITLE
UIGS-15: query-string ^7.1.2 fixing DoS CVE-2022-38900

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@folio/stripes-acq-components": "~3.3.0",
     "lodash": "^4.17.11",
     "prop-types": "^15.6.0",
-    "query-string": "^6.7.0"
+    "query-string": "^7.1.2"
   },
   "peerDependencies": {
     "@folio/stripes": "^7.0.0",


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2022-38900